### PR TITLE
Update Plan.js to use unit_amount instead of amount

### DIFF
--- a/client/src/components/Account.vue
+++ b/client/src/components/Account.vue
@@ -84,6 +84,7 @@
               <p>Want to increase your included requests?</p>
               <button class="upgrade" @click="$router.push('/pricing')">Upgrade your plan</button>
           </div>
+          </div>
         </section>
       </template>
     </section>

--- a/client/src/components/Pricing.vue
+++ b/client/src/components/Pricing.vue
@@ -32,6 +32,7 @@
         </p>
       </div>
     </div>
+    </div>
   </section>
 </template>
 

--- a/server/models/Plan.js
+++ b/server/models/Plan.js
@@ -190,11 +190,11 @@ class Plan extends Model {
             tiers: [
               {
                 up_to: plan.included,
-                amount: 0,
+                unit_amount: 0,
               },
               {
                 up_to: 'inf',
-                amount: plan.amount,
+                unit_amount: plan.amount,
               },
             ],
           });


### PR DESCRIPTION
Hello, 

I cloned the project, ran `npm install` then `npm run setup` and the script crashed.

According to the stripe docs regarding tier (below), `unit_amount` should be used, not `amount.` Not sure if the API changed. I didn't see a particular contribution guideline, hope the following is enough to help merge for future users. I haven't gotten far enough to see if there are other issues with `amount`, but figured I'd contribute this fix to get started.

I think there is also a missing `</div>` closing tag in `Pricing.vue` & `Account.js`, added separately in different commits.

Cool project!

https://stripe.com/docs/billing/subscriptions/tiers

## Error Encountered regarding setup:
```shell
🌍  Building Vue frontend
🔻  Dropping existing database tables
✨  Creating database tables for Typographic
✅  Database is ready
5 plans missing from this Stripe account.
⚡️  Creating missing plans...
Error: ⚠️  An error occurred during setup:
    at Function.setupPlans (/REDACTED/stripe-billing-typographic/server/models/Plan.js:215:15)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

I hopped into the debugger and received the following error:
```shell
message:"Received unknown parameter: tiers.amount"
param:"tiers.amount"
raw:Object {code: "parameter_unknown", doc_url: "https://stripe.com/docs/error-codes/parameter-unkn…", message: "Received unknown parameter: tiers.amount", …}
code:"parameter_unknown"
doc_url:"https://stripe.com/docs/error-codes/parameter-unknown"
headers:Object {server: "nginx", date: "Wed, 03 Oct 2018 02:38:54 GMT", content-type: "application/json", …}
message:"Received unknown parameter: tiers.amount"
param:"tiers.amount"
requestId:"REDACTED"
statusCode:400
type:"invalid_request_error"
__proto__:Object {constructor: , __defineGetter__: , __defineSetter__: , …}
rawType:"invalid_request_error"
requestId:"REDACTED"
stack:"Error: Received unknown parameter: tiers.amount\n    
at Constructor._Error (/REDACTED/stripe-billing-typographic/node_modules/stripe/lib/Error.js:12:17)\n    
at Constructor (/REDACTED/stripe-billing-typographic/node_modules/stripe/lib/utils.js:124:13)\n    
at new Constructor (/REDACTED/stripe-billing-typographic/node_modules/stripe/lib/utils.js:124:13)\n    
at Function.StripeError.generate (/REDACTED/stripe-billing-typographic/node_modules/stripe/lib/Error.js:57:12)\n    
at IncomingMessage.<anonymous> (/REDACTED/stripe-billing-typographic/node_modules/stripe/lib/StripeResource.js:170:39)\n    
at emitNone (events.js:120:20)\n    
at IncomingMessage.emit (events.js:218:7)\n    
at endReadableNT (_stream_readable.js:1054:12)\n    
at _combinedTickCallback (internal/process/next_tick.js:138:11)\n    
at process._tickCallback (internal/process/next_tick.js:180:9)"
statusCode:400
type:"StripeInvalidRequestError"
__proto__:Error {type: "StripeInvalidRequestError"}
```

## Error from components:
```
 npm run dev

> typographic@1.0.0 dev /REDACTED/stripe-billing-typographic
> rollup -c -w

[!] (VuePlugin plugin) Error: tag <div> has no matching end tag.
client/src/components/Account.vue
Error: tag <div> has no matching end tag.
```